### PR TITLE
COMPRESSION_CLOSE with Context ID 0 is malformed

### DIFF
--- a/draft-ietf-masque-connect-udp-listen.md
+++ b/draft-ietf-masque-connect-udp-listen.md
@@ -262,7 +262,7 @@ COMPRESSION_CLOSE Capsule {
 Once an endpoint has either sent or received a COMPRESSION_CLOSE for a given
 Context ID, it MUST NOT send any further datagrams with that Context ID.
 Since the value 0 was reserved by unextended connect-udp, a COMPRESSION_CLOSE
-capsule with Context ID zero is malformed.
+capsule with Context ID set to zero is malformed.
 
 Endpoints MAY close any context regardless of which endpoint registered it.
 This is useful for example, when a mapping is unused for a long time.


### PR DESCRIPTION
I think this is slightly more prescriptive, as receiving a malformed capsule is grounds for immediately terminating the connection.